### PR TITLE
Ignore falsy keys as they are not compatible with levelup

### DIFF
--- a/lib/KafkaCache.js
+++ b/lib/KafkaCache.js
@@ -9,7 +9,13 @@ function createDatabase({ valueEncoding, leveldown, keyEncoding }) {
   return levelup(encodedStore);
 }
 
-function encodeMessage(message, codec) {
+function encodeMessage(message, db) {
+
+  let codec = db.db.codec;
+  // TODO For some reason when two instances of memdown is created within the same process
+  // they start to refer to a common storage or something. This needs further investigation.
+  if (!codec) codec = db.db._db.codec;
+
   const { valueEncoding, keyEncoding } = codec.opts;
 
   return {
@@ -35,9 +41,14 @@ function KafkaCache({ streamReady, levelupOptions, resolver, log }) {
     log.debug({ currentTopicOffset }, 'Kafkacache stream ready to start consuming');
 
     stream(message => {
-      const { key, value } = encodeMessage(message, db.db.codec);
+      const { key, value } = encodeMessage(message, db);
 
-      db.put(key, resolver(value));
+      if (key) {
+        db.put(key, resolver(value));
+      } else {
+        log.error('Falsy keys are not supported! The risk of overwriting values is considered very big here!');
+        return;
+      }
 
       if (message.offset === currentTopicOffset)
         triggerReady();
@@ -46,7 +57,7 @@ function KafkaCache({ streamReady, levelupOptions, resolver, log }) {
     // Empty topics will never trigger a stream event. So we're already ready
     if (currentTopicOffset === -1)
       triggerReady();
-  })
+  }).catch(err => log.error(err));
 
   return {
     get: db.get.bind(db),

--- a/lib/KafkaCache.js
+++ b/lib/KafkaCache.js
@@ -47,7 +47,7 @@ function KafkaCache({ streamReady, levelupOptions, resolver, log }) {
         db.put(key, resolver(value));
       } else {
         log.error('Falsy keys are not supported! The risk of overwriting values is considered very big here!');
-        return;
+        // DON'T return here, we still need to trigger ready if this was it
       }
 
       if (message.offset === currentTopicOffset)

--- a/test/index.js
+++ b/test/index.js
@@ -3,7 +3,47 @@ const { expect } = require('chai');
 const KafkaCache = require('../lib/KafkaCache');
 const simple = require('simple-mock');
 
+const memdown = require('memdown');
+
 describe('KafkaCache unit-tests', function () {
+
+  afterEach(() => memdown.clearGlobalStore());
+
+  it('ignores payloads with missing keys', function (done) {
+
+    const logger = {
+      debug: simple.spy(),
+      error: simple.spy((...args) => console.error(...args)),
+      info: simple.spy(),
+      warn: simple.spy()
+    };
+
+    const mocks = {
+      stream: simple.mock()
+    };
+
+    const cache = new KafkaCache({
+      streamReady: Promise.resolve({ stream: mocks.stream, currentTopicOffset: -1 }),
+      log: logger,
+      levelupOptions: {
+        keyEncoding: 'utf-8',
+        valueEncoding: 'json'
+      },
+      resolver: x => x
+    });
+
+    const message = {
+      key: null,
+      value: Buffer.from(JSON.stringify({ foo: 'bar' }))
+    };
+
+    cache.onReady(() => {
+      mocks.stream.lastCall.arg(message);
+      expect(logger.error.lastCall.arg).to.contain('Falsy keys are not supported');
+
+      done();
+    });
+  });
 
   it('defaults to keyEncoding=string and valueEncoding=json', function (done) {
 


### PR DESCRIPTION
Topics containing messages with empty keys are a bad thing. But once they are there I'd argue it's easier to filter them than re-writing the topic.