### PR TITLE
Docker image for publish

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,1 @@
 node_modules/
-build-contracts/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 node_modules/
+build-contracts/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM yolean/node-kafka@sha256:3acd64fcc616872ece886d115a0514f23f0a3ee98238d2ac0f9043abbc6cea37
+
+COPY . /usr/src/yolean-kafka-cache
+
+RUN set -ex; \
+  export DEBIAN_FRONTEND=noninteractive; \
+  runDeps='libssl1.1 libsasl2-2'; \
+  buildDeps=' \
+    build-essential \
+    python \
+    libsasl2-dev \
+    libssl-dev \
+    zlib1g-dev \
+    liblz4-dev \
+    git \
+  '; \
+  apt-get update && apt-get install -y $runDeps $buildDeps --no-install-recommends; \
+  \
+  cd /usr/src/yolean-kafka-cache; \
+  mkdir node_modules && chown node node_modules; \
+  su node -c "npm link"; \
+  rm -rf /home/node/.npm; \
+  rm -rf /home/node/.node-gyp; \
+  \
+  apt-get purge -y --auto-remove $buildDeps; \
+  rm -rf /var/lib/apt/lists/*; \
+  rm -rf /var/log/apt /var/log/dpkg.log /var/log/alternatives.log;

--- a/build-contracts/basics/Dockerfile
+++ b/build-contracts/basics/Dockerfile
@@ -1,7 +1,7 @@
-FROM yolean/node as build
+FROM yolean/node-kafka@sha256:3acd64fcc616872ece886d115a0514f23f0a3ee98238d2ac0f9043abbc6cea37 as build
 
 RUN apt-get update && \
-  apt-get install make g++ python libsasl2-2 libsasl2-dev libssl-dev zlib1g-dev --no-install-recommends -y
+  apt-get install make g++ python libsasl2-2 libsasl2-dev libssl-dev zlib1g-dev --no-install-recommends git -y
 
 WORKDIR /kafka-cache
 
@@ -12,16 +12,16 @@ RUN npm install
 COPY . .
 
 
-FROM yolean/node
+FROM yolean/node-kafka@sha256:3acd64fcc616872ece886d115a0514f23f0a3ee98238d2ac0f9043abbc6cea37
 
 # Without this I'm unable to get things running due to missing
 # c libs like libssl.so.1.1
 RUN apt-get update && \
-  apt-get install libsasl2-2 libsasl2-dev libssl-dev zlib1g-dev --no-install-recommends -y
+  apt-get install libsasl2-2 libsasl2-dev libssl-dev zlib1g-dev --no-install-recommends git -y
 
 WORKDIR /usr/src/app
 
-COPY build-contracts/basics/package.json ./package.json
+COPY ./build-contracts/basics/package.json ./package.json
 
 RUN npm install
 

--- a/build-contracts/basics/Dockerfile
+++ b/build-contracts/basics/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && \
 
 WORKDIR /usr/src/app
 
-COPY ./build-contracts/basics/package.json ./package.json
+COPY build-contracts/basics/package.json ./package.json
 
 RUN npm install
 

--- a/build-contracts/docker-compose.yml
+++ b/build-contracts/docker-compose.yml
@@ -1,5 +1,11 @@
 version: "2.1"
 services:
+  # TODO we're not actually testing the target image, we only build it and then run tests in separate containers
+  yolean-kafka-cache:
+    image: yolean/node-kafka-cache
+    build: ../
+    labels:
+      - com.yolean.build-target
   zookeeper:
     image: solsson/kafka:1.0.0@sha256:17fdf1637426f45c93c65826670542e36b9f3394ede1cb61885c6a4befa8f72d
     entrypoint: ./bin/zookeeper-server-start.sh

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/Yolean/kafka-cache#readme",
   "devDependencies": {
+    "@types/node-rdkafka": "github:Yolean/node-rdkafka-types",
     "build-contract": "1.1.2",
     "chai": "4.1.2",
     "mocha": "4.0.1",
@@ -37,9 +38,8 @@
     "async": "2.6.0",
     "bunyan": "1.8.12",
     "encoding-down": "3.0.0",
-    "leveldown": "2.1.0",
-    "levelup": "2.0.1",
-    "memdown": "1.4.1",
-    "node-rdkafka": "2.2.3"
+    "leveldown": "2.1.1",
+    "levelup": "2.0.2",
+    "memdown": "2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "async": "2.6.0",
     "bunyan": "1.8.12",
     "encoding-down": "3.0.0",
-    "leveldown": "2.1.1",
-    "levelup": "2.0.2",
-    "memdown": "2.0.0"
+    "leveldown": "2.1.0",
+    "levelup": "2.0.1",
+    "memdown": "1.4.1"
   }
 }

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,7 +1,7 @@
-FROM yolean/node as build
+FROM yolean/node-kafka@sha256:3acd64fcc616872ece886d115a0514f23f0a3ee98238d2ac0f9043abbc6cea37
 
 RUN apt-get update && \
-  apt-get install make g++ python libsasl2-2 libsasl2-dev libssl-dev zlib1g-dev --no-install-recommends -y
+  apt-get install make g++ python libsasl2-2 libsasl2-dev libssl-dev zlib1g-dev git --no-install-recommends -y
 
 WORKDIR /kafka-cache
 


### PR DESCRIPTION
Implements #9 and replaces https://github.com/Yolean/docker-base/pull/6.

I noticed that we run memdown < 2 with level* 2+, but changelog for 2.0.0 says that they now match levelup v2.