### PR TITLE
Simplify build-contract build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,1 @@
 node_modules/
-build-contracts/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,3 @@
 node_modules/
+build-contracts/
+Dockerfile

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,3 @@
 node_modules/
 build-contracts/
-Dockerfile
+**/Dockerfile

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 node_modules/
+build-contracts/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM yolean/node-kafka@sha256:3acd64fcc616872ece886d115a0514f23f0a3ee98238d2ac0f9043abbc6cea37
+
+COPY . /usr/src/yolean-kafka-cache
+
+RUN set -ex; \
+  export DEBIAN_FRONTEND=noninteractive; \
+  runDeps='libssl1.1 libsasl2-2'; \
+  buildDeps=' \
+    build-essential \
+    python \
+    libsasl2-dev \
+    libssl-dev \
+    zlib1g-dev \
+    liblz4-dev \
+    git \
+  '; \
+  apt-get update && apt-get install -y $runDeps $buildDeps --no-install-recommends; \
+  \
+  cd /usr/src/yolean-kafka-cache; \
+  mkdir node_modules && chown node node_modules; \
+  su node -c "npm link"; \
+  rm -rf /home/node/.npm; \
+  rm -rf /home/node/.node-gyp; \
+  \
+  apt-get purge -y --auto-remove $buildDeps; \
+  rm -rf /var/lib/apt/lists/*; \
+  rm -rf /var/log/apt /var/log/dpkg.log /var/log/alternatives.log;

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM yolean/node-kafka@sha256:3acd64fcc616872ece886d115a0514f23f0a3ee98238d2ac0f9043abbc6cea37
+FROM yolean/node-kafka@sha256:32308f6369b1ecbedd97d0eda8ab8eac2a95a567ef7bbaffaef0d510c7b3c307
 
 COPY package.json /usr/src/yolean-kafka-cache/package.json
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM yolean/node-kafka@sha256:3acd64fcc616872ece886d115a0514f23f0a3ee98238d2ac0f9043abbc6cea37
 
-COPY . /usr/src/yolean-kafka-cache
+COPY package.json /usr/src/yolean-kafka-cache/package.json
 
 RUN set -ex; \
   export DEBIAN_FRONTEND=noninteractive; \
@@ -25,3 +25,5 @@ RUN set -ex; \
   apt-get purge -y --auto-remove $buildDeps; \
   rm -rf /var/lib/apt/lists/*; \
   rm -rf /var/log/apt /var/log/dpkg.log /var/log/alternatives.log;
+
+COPY . /usr/src/yolean-kafka-cache

--- a/build-contracts/basics/Dockerfile
+++ b/build-contracts/basics/Dockerfile
@@ -1,32 +1,11 @@
-FROM yolean/node-kafka@sha256:3acd64fcc616872ece886d115a0514f23f0a3ee98238d2ac0f9043abbc6cea37 as build
-
-RUN apt-get update && \
-  apt-get install make g++ python libsasl2-2 libsasl2-dev libssl-dev zlib1g-dev --no-install-recommends git -y
-
-WORKDIR /kafka-cache
-
-COPY package.json .
-
-RUN npm install
-
-COPY . .
-
-
-FROM yolean/node-kafka@sha256:3acd64fcc616872ece886d115a0514f23f0a3ee98238d2ac0f9043abbc6cea37
-
-# Without this I'm unable to get things running due to missing
-# c libs like libssl.so.1.1
-RUN apt-get update && \
-  apt-get install libsasl2-2 libsasl2-dev libssl-dev zlib1g-dev --no-install-recommends git -y
+FROM yolean/node-kafka-cache
 
 WORKDIR /usr/src/app
 
-COPY build-contracts/basics/package.json ./package.json
+COPY package.json .
 
-RUN npm install
+RUN npm install --development
 
-COPY --from=build /kafka-cache /kafka-cache
-
-COPY build-contracts/basics/ ./test
+COPY . ./test
 
 ENTRYPOINT ["./node_modules/.bin/mocha", "-t", "60000", "--exit"]

--- a/build-contracts/basics/Dockerfile
+++ b/build-contracts/basics/Dockerfile
@@ -1,7 +1,7 @@
-FROM yolean/node as build
+FROM yolean/node-kafka@sha256:3acd64fcc616872ece886d115a0514f23f0a3ee98238d2ac0f9043abbc6cea37 as build
 
 RUN apt-get update && \
-  apt-get install make g++ python libsasl2-2 libsasl2-dev libssl-dev zlib1g-dev --no-install-recommends -y
+  apt-get install make g++ python libsasl2-2 libsasl2-dev libssl-dev zlib1g-dev --no-install-recommends git -y
 
 WORKDIR /kafka-cache
 
@@ -12,16 +12,16 @@ RUN npm install
 COPY . .
 
 
-FROM yolean/node
+FROM yolean/node-kafka@sha256:3acd64fcc616872ece886d115a0514f23f0a3ee98238d2ac0f9043abbc6cea37
 
 # Without this I'm unable to get things running due to missing
 # c libs like libssl.so.1.1
 RUN apt-get update && \
-  apt-get install libsasl2-2 libsasl2-dev libssl-dev zlib1g-dev --no-install-recommends -y
+  apt-get install libsasl2-2 libsasl2-dev libssl-dev zlib1g-dev --no-install-recommends git -y
 
 WORKDIR /usr/src/app
 
-COPY build-contracts/basics/package.json ./package.json
+COPY ./build-contracts/basics/package.json ./package.json
 
 RUN npm install
 

--- a/build-contracts/basics/Dockerfile
+++ b/build-contracts/basics/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && \
 
 WORKDIR /usr/src/app
 
-COPY ./build-contracts/basics/package.json ./package.json
+COPY build-contracts/basics/package.json ./package.json
 
 RUN npm install
 

--- a/build-contracts/basics/index.js
+++ b/build-contracts/basics/index.js
@@ -2,7 +2,7 @@ const { expect } = require('chai');
 const bunyan = require('bunyan');
 const log = bunyan.createLogger({ name: 'test-basics', serializers: bunyan.stdSerializers });
 
-const KafkaCache = require('/kafka-cache');
+const KafkaCache = require('kafka-cache');
 
 const uuid = require('uuid');
 

--- a/build-contracts/docker-compose.yml
+++ b/build-contracts/docker-compose.yml
@@ -1,5 +1,11 @@
 version: "2.1"
 services:
+  # TODO we're not actually testing the target image, we only build it and then run tests in separate containers
+  yolean-kafka-cache:
+    image: yolean/node-kafka-cache
+    build: ../
+    labels:
+      - com.yolean.build-target
   zookeeper:
     image: solsson/kafka:1.0.0@sha256:17fdf1637426f45c93c65826670542e36b9f3394ede1cb61885c6a4befa8f72d
     entrypoint: ./bin/zookeeper-server-start.sh

--- a/build-contracts/docker-compose.yml
+++ b/build-contracts/docker-compose.yml
@@ -41,17 +41,17 @@ services:
     environment:
       TOPIC_NAME: build-contracts.basics.002
   test-basics:
-    build:
-      context: ../
-      dockerfile: build-contracts/basics/Dockerfile
+    depends_on:
+    - yolean-kafka-cache
+    build: ./basics
     labels:
       - com.yolean.build-contract
     links:
       - kafka
       - zookeeper
   unit-tests:
-    build:
-      context: ../
-      dockerfile: ./test/Dockerfile
+    depends_on:
+    - yolean-kafka-cache
+    build: ../test
     labels:
       - com.yolean.build-contract

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "abstract-leveldown": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-3.0.0.tgz",
-      "integrity": "sha512-KUWx9UWGQD12zsmLNj64/pndaz4iJh/Pj7nopgkfDG6RlCcbMZvT6+9l7dchK4idog2Is8VdC/PvNbFuFmalIQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-4.0.3.tgz",
+      "integrity": "sha512-qsIHFQy0u17JqSY+3ZUT+ykqxYY17yOfvAsLkFkw8kSQqi05d1jyj0bCuSX6sjYlXuY9cKpgUt5EudQdP4aXyA==",
       "requires": {
         "xtend": "4.0.1"
       }
@@ -28,7 +28,7 @@
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "requires": {
         "delegates": "1.0.0",
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.5"
       }
     },
     "argparse": {
@@ -69,7 +69,7 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
       "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.5"
       }
     },
     "brace-expansion": {
@@ -167,6 +167,14 @@
         "ms": "2.0.0"
       }
     },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "requires": {
+        "mimic-response": "1.0.0"
+      }
+    },
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
@@ -182,17 +190,22 @@
       "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
     },
     "deferred-leveldown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-2.0.3.tgz",
-      "integrity": "sha512-8c2Hv+vIwKNc7qqy4zE3t5DIsln+FQnudcyjLYstHwLFg7XnXZT/H8gQb8lj6xi8xqGM0Bz633ZWcCkonycBTA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-3.0.0.tgz",
+      "integrity": "sha512-ajbXqRPMXRlcdyt0TuWqknOJkp1JgQjGB7xOl2V+ebol7/U11E9h3/nCZAtN1M7djmAJEIhypCUc1tIWxdQAuQ==",
       "requires": {
-        "abstract-leveldown": "3.0.0"
+        "abstract-leveldown": "4.0.3"
       }
     },
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
     },
     "diff": {
       "version": "3.3.1",
@@ -210,29 +223,29 @@
       }
     },
     "encoding-down": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-3.0.0.tgz",
-      "integrity": "sha1-IGjLZ7E3G14frJtfF44FpVUr+l4=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-4.0.0.tgz",
+      "integrity": "sha512-jyhdwd61FJEXJQk9KaaUIXXoe6Uix15lBGY/pBv1qEqFgOuzSwgREeb0eaP7ZdA7C3rNFBhs6Fj/RifNkLCaFw==",
       "requires": {
-        "abstract-leveldown": "3.0.0",
+        "abstract-leveldown": "4.0.3",
         "level-codec": "8.0.0",
-        "level-errors": "1.1.1"
+        "level-errors": "1.1.2"
       }
     },
     "end-of-stream": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
         "once": "1.4.0"
       }
     },
     "errno": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-      "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "requires": {
-        "prr": "0.0.0"
+        "prr": "1.0.1"
       }
     },
     "escape-string-regexp": {
@@ -368,11 +381,11 @@
       "integrity": "sha512-gNZlo1HRHz0BWxzGCyNf7xntAs2HKOPvvRBWtXsoDvEX4vMYnSTBS6ZnxoaiX7nhxSBPpegRa8CQ/hnfGBKk3Q=="
     },
     "level-errors": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.1.1.tgz",
-      "integrity": "sha512-9MIIbizlJgWFQ6m45ehVuSrpzFxwJQmZYD6sfmiizhdmWMNUf41mBYpUJEeCslIa3sB4vdsIFCimPdDZkWznwA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.1.2.tgz",
+      "integrity": "sha512-Sw/IJwWbPKF5Ai4Wz60B52yj0zYeqzObLh8k1Tk88jVmD51cJSKWSYpRyhVIvFzZdvsPqlH5wfhp/yxdsaQH4w==",
       "requires": {
-        "errno": "0.1.4"
+        "errno": "0.1.7"
       }
     },
     "level-iterator-stream": {
@@ -381,29 +394,29 @@
       "integrity": "sha512-TWOYw8HR5mhj6xwoVLo0yu26RPL6v28KgvhK1kY1CJf9LyL+rJXjx99zhORTYhN9ysOBIH+iaxAiqRteA+C1/g==",
       "requires": {
         "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
+        "readable-stream": "2.3.5",
         "xtend": "4.0.1"
       }
     },
     "leveldown": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-2.1.0.tgz",
-      "integrity": "sha512-8bpEe8++0dfNnGVDC7rny/9X8IubxSMzU387E6neaUhSnvS4yNeFKXbiTkLhJoWariNehlzFnU+XwY1aSgjoww==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-3.0.0.tgz",
+      "integrity": "sha512-CA2mRUDTgVscTDOCvHSgYvksqj1VW7g3ss2idWfITSB7l201ahQJ81cwLTupW76idbjpx7zmmmpdttYnnHWWtA==",
       "requires": {
-        "abstract-leveldown": "3.0.0",
+        "abstract-leveldown": "4.0.3",
         "bindings": "1.3.0",
         "fast-future": "1.0.2",
         "nan": "2.8.0",
-        "prebuild-install": "2.3.0"
+        "prebuild-install": "2.5.1"
       }
     },
     "levelup": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/levelup/-/levelup-2.0.1.tgz",
-      "integrity": "sha1-PckbPmMtN8nlRiOchkEYsATJ+GA=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-2.0.2.tgz",
+      "integrity": "sha512-us+nTLUyd/eLnclYYddOCdAVw1hnymGx/9p4Jr5ThohStsjLqMVmbYiz6/SYFZEPXNF+AKQSvh6fA2e2KZpC8w==",
       "requires": {
-        "deferred-leveldown": "2.0.3",
-        "level-errors": "1.1.1",
+        "deferred-leveldown": "3.0.0",
+        "level-errors": "1.1.2",
         "level-iterator-stream": "2.0.0",
         "xtend": "4.0.1"
       }
@@ -419,27 +432,22 @@
       "integrity": "sha1-tlul/LNJopkkyOMz98alVi8uSEI="
     },
     "memdown": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
-      "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/memdown/-/memdown-2.0.0.tgz",
+      "integrity": "sha1-QKRQGzmJCuZBUT8qlNc0LVlMLYM=",
       "requires": {
-        "abstract-leveldown": "2.7.2",
+        "abstract-leveldown": "4.0.3",
         "functional-red-black-tree": "1.0.1",
         "immediate": "3.2.3",
         "inherits": "2.0.3",
         "ltgt": "2.2.0",
         "safe-buffer": "5.1.1"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "2.7.2",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
-          "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
-          "requires": {
-            "xtend": "4.0.1"
-          }
-        }
       }
+    },
+    "mimic-response": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.0.tgz",
+      "integrity": "sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -522,20 +530,11 @@
       "optional": true
     },
     "node-abi": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.1.2.tgz",
-      "integrity": "sha512-hmUtb8m75RSi7N+zZLYqe75XDvZB+6LyTBPkj2DConvNgQet2e3BIqEwe1LLvqMrfyjabuT5ZOrTioLCH1HTdA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.3.0.tgz",
+      "integrity": "sha512-zwm6vU3SsVgw3e9fu48JBaRBCJGIvAgysDsqtf5+vEexFE71bEOtaMWb5zr/zODZNzTPtQlqUUpC79k68Hspow==",
       "requires": {
-        "semver": "5.4.1"
-      }
-    },
-    "node-rdkafka": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/node-rdkafka/-/node-rdkafka-2.2.3.tgz",
-      "integrity": "sha1-BdjK/brye/Ho7yuOW/Oa+1mi5wE=",
-      "requires": {
-        "bindings": "1.3.0",
-        "nan": "2.8.0"
+        "semver": "5.5.0"
       }
     },
     "noop-logger": {
@@ -589,49 +588,50 @@
       "dev": true
     },
     "prebuild-install": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.3.0.tgz",
-      "integrity": "sha512-gzjq2oHB8oMbzJSsSh9MQ64zrXZGt092/uT4TLZlz2qnrPxpWqp4vYB7LZrDxnlxf5RfbCjkgDI/z0EIVuYzAw==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.1.tgz",
+      "integrity": "sha512-3DX9L6pzwc1m1ksMkW3Ky2WLgPQUBiySOfXVl3WZyAeJSyJb4wtoH9OmeRGcubAWsMlLiL8BTHbwfm/jPQE9Ag==",
       "requires": {
+        "detect-libc": "1.0.3",
         "expand-template": "1.1.0",
         "github-from-package": "0.0.0",
         "minimist": "1.2.0",
         "mkdirp": "0.5.1",
-        "node-abi": "2.1.2",
+        "node-abi": "2.3.0",
         "noop-logger": "0.1.1",
         "npmlog": "4.1.2",
         "os-homedir": "1.0.2",
-        "pump": "1.0.3",
-        "rc": "1.2.2",
-        "simple-get": "1.4.3",
+        "pump": "2.0.1",
+        "rc": "1.2.6",
+        "simple-get": "2.7.0",
         "tar-fs": "1.16.0",
         "tunnel-agent": "0.6.0",
-        "xtend": "4.0.1"
+        "which-pm-runs": "1.0.0"
       }
     },
     "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "prr": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-      "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
     },
     "pump": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-      "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
       "requires": {
-        "end-of-stream": "1.4.0",
+        "end-of-stream": "1.4.1",
         "once": "1.4.0"
       }
     },
     "rc": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz",
-      "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.6.tgz",
+      "integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
       "requires": {
         "deep-extend": "0.4.2",
         "ini": "1.3.5",
@@ -640,14 +640,14 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+      "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
         "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
+        "process-nextick-args": "2.0.0",
         "safe-buffer": "5.1.1",
         "string_decoder": "1.0.3",
         "util-deprecate": "1.0.2"
@@ -689,9 +689,9 @@
       "optional": true
     },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -703,14 +703,19 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
+    "simple-concat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
+      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
+    },
     "simple-get": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-1.4.3.tgz",
-      "integrity": "sha1-6XVe2kB+ltpAxeUVjJ6jezO+y+s=",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.7.0.tgz",
+      "integrity": "sha512-RkE9rGPHcxYZ/baYmgJtOSM63vH0Vyq+ma5TijBcLla41SWlh8t6XYIGMR/oeZcmr+/G8k+zrClkkVrtnQ0esg==",
       "requires": {
+        "decompress-response": "3.3.0",
         "once": "1.4.0",
-        "unzip-response": "1.0.2",
-        "xtend": "4.0.1"
+        "simple-concat": "1.0.0"
       }
     },
     "simple-mock": {
@@ -725,14 +730,6 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -741,6 +738,14 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {
@@ -774,6 +779,17 @@
         "mkdirp": "0.5.1",
         "pump": "1.0.3",
         "tar-stream": "1.5.5"
+      },
+      "dependencies": {
+        "pump": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+          "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+          "requires": {
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
+          }
+        }
       }
     },
     "tar-stream": {
@@ -782,8 +798,8 @@
       "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
       "requires": {
         "bl": "1.2.1",
-        "end-of-stream": "1.4.0",
-        "readable-stream": "2.3.3",
+        "end-of-stream": "1.4.1",
+        "readable-stream": "2.3.5",
         "xtend": "4.0.1"
       }
     },
@@ -801,15 +817,15 @@
       "integrity": "sha512-N9IvkQslUGYGC24RkJk1ba99foK6TkwC2FHAEBlQFBP0RxQZS8ZpJuAZcwiY/w9ZJHFQb1aOXBI60OdxhTrwEQ==",
       "dev": true
     },
-    "unzip-response": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
-      "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4="
-    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "which-pm-runs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
     },
     "wide-align": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/Yolean/kafka-cache#readme",
   "devDependencies": {
+    "@types/node-rdkafka": "github:Yolean/node-rdkafka-types",
     "build-contract": "1.1.2",
     "chai": "4.1.2",
     "mocha": "4.0.1",
@@ -37,9 +38,8 @@
     "async": "2.6.0",
     "bunyan": "1.8.12",
     "encoding-down": "3.0.0",
-    "leveldown": "2.1.0",
-    "levelup": "2.0.1",
-    "memdown": "1.4.1",
-    "node-rdkafka": "2.2.3"
+    "leveldown": "2.1.1",
+    "levelup": "2.0.2",
+    "memdown": "2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
   "dependencies": {
     "async": "2.6.0",
     "bunyan": "1.8.12",
-    "encoding-down": "3.0.0",
-    "leveldown": "2.1.0",
-    "levelup": "2.0.1",
-    "memdown": "1.4.1"
+    "encoding-down": "4.0.0",
+    "leveldown": "3.0.0",
+    "levelup": "2.0.2",
+    "memdown": "2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "async": "2.6.0",
     "bunyan": "1.8.12",
     "encoding-down": "3.0.0",
-    "leveldown": "2.1.1",
-    "levelup": "2.0.2",
-    "memdown": "2.0.0"
+    "leveldown": "2.1.0",
+    "levelup": "2.0.1",
+    "memdown": "1.4.1"
   }
 }

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,7 +1,7 @@
-FROM yolean/node as build
+FROM yolean/node-kafka@sha256:3acd64fcc616872ece886d115a0514f23f0a3ee98238d2ac0f9043abbc6cea37
 
 RUN apt-get update && \
-  apt-get install make g++ python libsasl2-2 libsasl2-dev libssl-dev zlib1g-dev --no-install-recommends -y
+  apt-get install make g++ python libsasl2-2 libsasl2-dev libssl-dev zlib1g-dev git --no-install-recommends -y
 
 WORKDIR /kafka-cache
 

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,14 +1,5 @@
-FROM yolean/node-kafka@sha256:3acd64fcc616872ece886d115a0514f23f0a3ee98238d2ac0f9043abbc6cea37
+FROM yolean/node-kafka-cache
 
-RUN apt-get update && \
-  apt-get install make g++ python libsasl2-2 libsasl2-dev libssl-dev zlib1g-dev git --no-install-recommends -y
-
-WORKDIR /kafka-cache
-
-COPY package.json .
-
-RUN npm install
-
-COPY . .
+WORKDIR /usr/src/yolean-kafka-cache
 
 ENTRYPOINT ["./node_modules/.bin/mocha", "-t", "60000", "--exit"]

--- a/test/index.js
+++ b/test/index.js
@@ -14,8 +14,6 @@ function createMockMetricsApi() {
 
 describe('KafkaCache unit-tests', function () {
 
-  afterEach(() => memdown.clearGlobalStore());
-
   it('ignores payloads with missing keys but logs them and reports them as metrics', function (done) {
 
     const logger = {


### PR DESCRIPTION
and upgrade to memdown 2 because they say it brings parity with levelup 2 which we already had.

Includes #10 

Pushed `yolean/node-kafka-cache@sha256:53492561bbffa974339e3ece68c32ba597de5e2e5a24c637d6f5777b6bbf0010`.