### PR TITLE
Can we happy-hack a sidecar concept?

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
+    "base64-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.0.2.tgz",
+      "integrity": "sha1-R0IRyV5s8qVH20YeT2d4tR0I+mU="
+    },
     "bindings": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
@@ -79,6 +84,15 @@
       "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
       "requires": {
         "readable-stream": "^2.0.5"
+      }
+    },
+    "bops": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/bops/-/bops-1.0.0.tgz",
+      "integrity": "sha1-YxqJKPEXhBfrb3Bs9prNteWk6q0=",
+      "requires": {
+        "base64-js": "1.0.2",
+        "to-utf8": "0.0.1"
       }
     },
     "brace-expansion": {
@@ -271,6 +285,16 @@
         "nan": "^2.3.3"
       }
     },
+    "duplex": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npmjs.org/duplex/-/duplex-1.0.0.tgz",
+      "integrity": "sha1-arxcFuwX5MV4V4cnEmcAWQ06Ldo="
+    },
+    "duplexer": {
+      "version": "0.1.1",
+      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+    },
     "encoding-down": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-4.0.0.tgz",
@@ -430,6 +454,11 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
+    "json-buffer": {
+      "version": "2.0.11",
+      "resolved": "http://registry.npmjs.org/json-buffer/-/json-buffer-2.0.11.tgz",
+      "integrity": "sha1-PkQf2jCYvo0eMXGtWRvGKjPi1V8="
+    },
     "level-codec": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-8.0.0.tgz",
@@ -451,6 +480,21 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.5",
         "xtend": "^4.0.0"
+      }
+    },
+    "level-manifest": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npmjs.org/level-manifest/-/level-manifest-1.2.0.tgz",
+      "integrity": "sha1-BiANOnaL/WtRgbJ7+psO/LsG/lU=",
+      "requires": {
+        "deep-extend": "~0.2.5"
+      },
+      "dependencies": {
+        "deep-extend": {
+          "version": "0.2.11",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
+          "integrity": "sha1-eha6aXKRMjQFBhcElLyD9wdv4I8="
+        }
       }
     },
     "leveldown": {
@@ -560,6 +604,94 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
+    },
+    "msgpack-js": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/msgpack-js/-/msgpack-js-0.3.0.tgz",
+      "integrity": "sha1-Aw7AjFlW+cp9F9QKVy1Tlv7BCSM=",
+      "requires": {
+        "bops": "~0.0.6"
+      },
+      "dependencies": {
+        "base64-js": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.2.tgz",
+          "integrity": "sha1-Ak8Pcq+iW3X5wO5zzU9V7Bvtl4Q="
+        },
+        "bops": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/bops/-/bops-0.0.7.tgz",
+          "integrity": "sha1-tKClqDmkBkVK8P4FqLkaenZqVOI=",
+          "requires": {
+            "base64-js": "0.0.2",
+            "to-utf8": "0.0.1"
+          }
+        }
+      }
+    },
+    "msgpack-stream": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/msgpack-stream/-/msgpack-stream-0.0.13.tgz",
+      "integrity": "sha1-UKZzrE6uyl43cBkk0JPUM1DB5Sw=",
+      "requires": {
+        "bops": "1.0.0",
+        "msgpack-js": "0.3.0",
+        "through": "2.3.4"
+      },
+      "dependencies": {
+        "through": {
+          "version": "2.3.4",
+          "resolved": "http://registry.npmjs.org/through/-/through-2.3.4.tgz",
+          "integrity": "sha1-SV5A6Nio6uvHwnXqiMK4/BTFZFU="
+        }
+      }
+    },
+    "multilevel": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/multilevel/-/multilevel-7.2.3.tgz",
+      "integrity": "sha512-jpn9Q9C+GqwrLbfEBD3ZLCZjvVzHrg9D05zk44DD3ifsUM85O2GCn6U+0uujsVAtXN5V8KMFbyZohHjXEsxYgQ==",
+      "requires": {
+        "duplexer": "^0.1.1",
+        "level-manifest": "^1.2.0",
+        "mux-demux": "^3.7.9",
+        "rpc-stream": "^2.1.2",
+        "stream-combiner": "^0.2.2",
+        "tmp-stream": "^0.3.2"
+      }
+    },
+    "mux-demux": {
+      "version": "3.7.9",
+      "resolved": "http://registry.npmjs.org/mux-demux/-/mux-demux-3.7.9.tgz",
+      "integrity": "sha1-NTZ3GP02AcgLzi63YlMVdtekrO8=",
+      "requires": {
+        "duplex": "~1.0.0",
+        "json-buffer": "~2.0.4",
+        "msgpack-stream": "~0.0.10",
+        "stream-combiner": "0.0.2",
+        "stream-serializer": "~1.1.1",
+        "through": "~2.3.1",
+        "xtend": "~1.0.3"
+      },
+      "dependencies": {
+        "duplexer": {
+          "version": "0.0.4",
+          "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.0.4.tgz",
+          "integrity": "sha1-r8t/H4uNdPggcmFx1dZKyeSo/yA="
+        },
+        "stream-combiner": {
+          "version": "0.0.2",
+          "resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.2.tgz",
+          "integrity": "sha1-3+DnRnV0JWXnbGBWeI6lwjvZfbQ=",
+          "requires": {
+            "duplexer": "~0.0.3"
+          }
+        },
+        "xtend": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-1.0.3.tgz",
+          "integrity": "sha1-P12Tc1PM7Y4IU5mlY/2yJUHClgo="
+        }
+      }
     },
     "mv": {
       "version": "2.1.1",
@@ -731,6 +863,22 @@
         }
       }
     },
+    "rpc-stream": {
+      "version": "2.1.2",
+      "resolved": "http://registry.npmjs.org/rpc-stream/-/rpc-stream-2.1.2.tgz",
+      "integrity": "sha1-wkpt7lKfOGKEuw1v0xK5scDYQps=",
+      "requires": {
+        "stream-serializer": "~1.0.0",
+        "through": "~2.3.1"
+      },
+      "dependencies": {
+        "stream-serializer": {
+          "version": "1.0.0",
+          "resolved": "http://registry.npmjs.org/stream-serializer/-/stream-serializer-1.0.0.tgz",
+          "integrity": "sha1-qiEvNDkg+Mxq/8ZcJAunAOtsSbk="
+        }
+      }
+    },
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
@@ -783,6 +931,20 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "stream-combiner": {
+      "version": "0.2.2",
+      "resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+      "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
+      "requires": {
+        "duplexer": "~0.1.1",
+        "through": "~2.3.4"
+      }
+    },
+    "stream-serializer": {
+      "version": "1.1.2",
+      "resolved": "http://registry.npmjs.org/stream-serializer/-/stream-serializer-1.1.2.tgz",
+      "integrity": "sha1-wfl9FdolH1lK4n1B7IraCahG408="
     },
     "string-width": {
       "version": "1.0.2",
@@ -857,11 +1019,46 @@
         "xtend": "^4.0.0"
       }
     },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "throughout": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/throughout/-/throughout-0.0.0.tgz",
+      "integrity": "sha1-2pNVJyMaeUTapg061HoyQprxqME=",
+      "requires": {
+        "duplexer": "~0.0.2",
+        "through": "~2.3.4"
+      },
+      "dependencies": {
+        "duplexer": {
+          "version": "0.0.4",
+          "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.0.4.tgz",
+          "integrity": "sha1-r8t/H4uNdPggcmFx1dZKyeSo/yA="
+        }
+      }
+    },
+    "tmp-stream": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tmp-stream/-/tmp-stream-0.3.2.tgz",
+      "integrity": "sha1-3hFf11PQ3MwojyarQOtuvu5dGyA=",
+      "requires": {
+        "through": "~2.3.4",
+        "throughout": "0.0.0"
+      }
+    },
     "to-buffer": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
       "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
       "dev": true
+    },
+    "to-utf8": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/to-utf8/-/to-utf8-0.0.1.tgz",
+      "integrity": "sha1-0Xrqcv8vujm55DYBvns/9y4ImFI="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "leveldown": "3.0.0",
     "levelup": "2.0.2",
     "memdown": "2.0.0",
-    "moment": "2.22.2"
+    "moment": "2.22.2",
+    "multilevel": "7.2.3"
   }
 }


### PR DESCRIPTION
Docker Compose aside ...

Maybe Knative will beat us to the Kafka sidecar pattern :) but development today with countless restarts of a service that needed to warm up a kafka connection only for simple table-topic lookups got me thinking about the advantages with a kafka-cache sidecar.

Also integration testing required kafka while all I'd actually want was to pre-load some key-value pairs. Maybe something like https://www.npmjs.com/package/jsondown could provide that. The sidecar pattern would make kafka-cache and a stub interchangeable at runtime.

While I was in this mood I also had crazy ideas about using annotations to declare what topics and/or types to produce and/or consume, as solution to https://github.com/Yolean/kubernetes-kafka/issues/101. Maybe [CloudEvents](https://github.com/knative/docs/blob/581bd2f5390aa3e959b4ba8c4e2e280493234fc8/eventing/README.md#design-overview) will beat us to that :)