### PR TITLE
Require the env 'KAFKA_CACHE_GROUP_SUFFIX' to be set for all runtimes…

### DIFF
--- a/build-contracts/docker-compose.yml
+++ b/build-contracts/docker-compose.yml
@@ -46,6 +46,8 @@ services:
     build: ./basics
     labels:
       - com.yolean.build-contract
+    environment:
+      KAFKA_CACHE_GROUP_SUFFIX: basics-foo-bar-12345
     links:
       - kafka
       - zookeeper
@@ -59,6 +61,8 @@ services:
       - kafka
       - zookeeper
     working_dir: /usr/src/yolean-kafka-cache
+    environment:
+      KAFKA_CACHE_GROUP_SUFFIX: itest-foo-bar-12345
     entrypoint:
       - npm
       - run

--- a/lib/index.js
+++ b/lib/index.js
@@ -113,6 +113,13 @@ function createMetricsApi({ metrics, log }) {
   }
 }
 
+function getGroupId() {
+  const suffix = process.env.KAFKA_CACHE_GROUP_SUFFIX;
+  if (!suffix) throw new Error('Missing env KAFKA_CACHE_GROUP_SUFFIX');
+
+  return 'node-kafka-cache_' + suffix;
+}
+
 function createKafkaStream({ topic, kafkaHost, consumeFromTimestamp, log }) {
 
   const consumerOptions = {
@@ -133,8 +140,10 @@ function createKafkaStream({ topic, kafkaHost, consumeFromTimestamp, log }) {
 
       log.info({ topic, kafkaHost, consumeFromOffset, consumeFromTimestamp }, 'Setting up kafka stream starting from offset');
 
+      const groupId = getGroupId();
+
       resolve({
-        stream: kafka.stream.bind(null, topic, 'node-kafka-cache', consumerOptions, consumeFromOffset),
+        stream: kafka.stream.bind(null, topic, groupId, consumerOptions, consumeFromOffset),
         currentTopicOffset: readyOffset
       });
     });


### PR DESCRIPTION
…, should allow us to use burrows prometheus metrics to monitor consumer lag