### PR TITLE
Wait for offset

### DIFF
--- a/build-contracts/docker-compose.yml
+++ b/build-contracts/docker-compose.yml
@@ -46,6 +46,8 @@ services:
     build: ./basics
     labels:
       - com.yolean.build-contract
+    environment:
+      KAFKA_CACHE_GROUP_SUFFIX: basics-foo-bar-12345
     links:
       - kafka
       - zookeeper
@@ -59,6 +61,8 @@ services:
       - kafka
       - zookeeper
     working_dir: /usr/src/yolean-kafka-cache
+    environment:
+      KAFKA_CACHE_GROUP_SUFFIX: itest-foo-bar-12345
     entrypoint:
       - npm
       - run

--- a/lib/KafkaCache.js
+++ b/lib/KafkaCache.js
@@ -50,10 +50,10 @@ function KafkaCache({ streamReady, kafkaWrite, compressValues, levelupOptions, r
     });
   }
 
-  const onOffsetReceived = async (offset, value) => {
+  const onOffsetReceived = async (offset) => {
     lastOffset = offset;
     const callbacks = offsetWaiters.get(offset) || [];
-    log.debug({ nCallbacks: callbacks.length, offset, value }, 'Notifying callbacks for offset');
+    log.debug({ nCallbacks: callbacks.length, offset }, 'Notifying callbacks for offset');
     callbacks.forEach(cb => cb());
     offsetWaiters.delete(offset);
   }
@@ -74,9 +74,8 @@ function KafkaCache({ streamReady, kafkaWrite, compressValues, levelupOptions, r
         !isBuffer && !!key
       );
 
-      const resolvedValue = resolver(value);
       if (isKeySupportedByLevelup) {
-        db.put(key, resolvedValue);
+        db.put(key, resolver(value));
       } else {
         metrics.incMissingKey();
         log.error('Falsy keys are not supported! The risk of overwriting values is considered very big here!');
@@ -88,7 +87,7 @@ function KafkaCache({ streamReady, kafkaWrite, compressValues, levelupOptions, r
       }
 
       if (message.offset >= currentTopicOffset)
-        setImmediate(() => onOffsetReceived(message.offset, resolvedValue));
+        setImmediate(() => onOffsetReceived(message.offset));
     }, metrics.onKafkaStats);
 
     // Empty topics will never trigger a stream event. So we're already ready

--- a/lib/KafkaCache.js
+++ b/lib/KafkaCache.js
@@ -29,11 +29,31 @@ function KafkaCache({ streamReady, kafkaWrite, compressValues, levelupOptions, r
   const db = createDatabase(levelupOptions);
 
   let isReady = false, callbacks = [];
+  const offsetWaiters = new Map();
+  let lastOffset = -1;
 
   const triggerReady = () => {
     isReady = true;
     callbacks.forEach(callback => callback());
     callbacks = [];
+  }
+
+  const waitForOffset = async (offset) => {
+    if (!Number.isInteger(offset)) throw new Error('Invalid offset: ' + offset);
+    if (lastOffset >= offset) return Promise.resolve();
+
+    return new Promise(resolve => {
+      const callbacks = offsetWaiters.get(offset) || [];
+      offsetWaiters.set(offset, callbacks);
+      callbacks.push(resolve);
+    });
+  }
+
+  const onOffsetReceived = async (offset, value) => {
+    lastOffset = offset;
+    const callbacks = offsetWaiters.get(offset) || [];
+    callbacks.forEach(cb => cb(value));
+    offsetWaiters.delete(offset);
   }
 
   streamReady.then(({ stream, currentTopicOffset }) => {
@@ -52,8 +72,9 @@ function KafkaCache({ streamReady, kafkaWrite, compressValues, levelupOptions, r
         !isBuffer && !!key
       );
 
+      const resolvedValue = resolver(value);
       if (isKeySupportedByLevelup) {
-        db.put(key, resolver(value));
+        db.put(key, resolvedValue);
       } else {
         metrics.incMissingKey();
         log.error('Falsy keys are not supported! The risk of overwriting values is considered very big here!');
@@ -63,6 +84,9 @@ function KafkaCache({ streamReady, kafkaWrite, compressValues, levelupOptions, r
       if (message.offset === currentTopicOffset) {
         setImmediate(triggerReady);
       }
+
+      // TODO Only when message.offset >= currentTopicOffset?
+      onOffsetReceived(message.offset, resolvedValue);
     }, metrics.onKafkaStats);
 
     // Empty topics will never trigger a stream event. So we're already ready
@@ -77,7 +101,10 @@ function KafkaCache({ streamReady, kafkaWrite, compressValues, levelupOptions, r
 
   return {
     get: db.get.bind(db),
-    put: kafkaWrite,
+    put: async (key, value, callback) => {
+      return kafkaWrite(key, value, callback);
+    },
+    waitForOffset,
     createReadStream: db.createReadStream.bind(db),
     on: db.on.bind(db),
     onReady: fn => {

--- a/lib/KafkaCache.js
+++ b/lib/KafkaCache.js
@@ -102,9 +102,7 @@ function KafkaCache({ streamReady, kafkaWrite, compressValues, levelupOptions, r
 
   return {
     get: db.get.bind(db),
-    put: async (key, value, callback) => {
-      return kafkaWrite(key, value, callback);
-    },
+    put: kafkaWrite,
     waitForOffset,
     createReadStream: db.createReadStream.bind(db),
     on: db.on.bind(db),

--- a/lib/KafkaCache.js
+++ b/lib/KafkaCache.js
@@ -52,6 +52,7 @@ function KafkaCache({ streamReady, kafkaWrite, compressValues, levelupOptions, r
   const onOffsetReceived = async (offset, value) => {
     lastOffset = offset;
     const callbacks = offsetWaiters.get(offset) || [];
+    log.debug({ nCallbacks: callbacks.length, offset }, 'Notifying callbacks for offset');
     callbacks.forEach(cb => cb(value));
     offsetWaiters.delete(offset);
   }
@@ -86,7 +87,7 @@ function KafkaCache({ streamReady, kafkaWrite, compressValues, levelupOptions, r
       }
 
       // TODO Only when message.offset >= currentTopicOffset?
-      onOffsetReceived(message.offset, resolvedValue);
+      setImmediate(() => onOffsetReceived(message.offset, resolvedValue));
     }, metrics.onKafkaStats);
 
     // Empty topics will never trigger a stream event. So we're already ready

--- a/lib/KafkaCache.js
+++ b/lib/KafkaCache.js
@@ -39,6 +39,7 @@ function KafkaCache({ streamReady, kafkaWrite, compressValues, levelupOptions, r
   }
 
   const waitForOffset = async (offset) => {
+    if (!isReady) throw new Error('cache.onReady() must have been triggered before cache.waitForOffset() is available!');
     if (!Number.isInteger(offset)) throw new Error('Invalid offset: ' + offset);
     if (lastOffset >= offset) return Promise.resolve();
 
@@ -52,8 +53,8 @@ function KafkaCache({ streamReady, kafkaWrite, compressValues, levelupOptions, r
   const onOffsetReceived = async (offset, value) => {
     lastOffset = offset;
     const callbacks = offsetWaiters.get(offset) || [];
-    log.debug({ nCallbacks: callbacks.length, offset }, 'Notifying callbacks for offset');
-    callbacks.forEach(cb => cb(value));
+    log.debug({ nCallbacks: callbacks.length, offset, value }, 'Notifying callbacks for offset');
+    callbacks.forEach(cb => cb());
     offsetWaiters.delete(offset);
   }
 
@@ -86,8 +87,8 @@ function KafkaCache({ streamReady, kafkaWrite, compressValues, levelupOptions, r
         setImmediate(triggerReady);
       }
 
-      // TODO Only when message.offset >= currentTopicOffset?
-      setImmediate(() => onOffsetReceived(message.offset, resolvedValue));
+      if (message.offset >= currentTopicOffset)
+        setImmediate(() => onOffsetReceived(message.offset, resolvedValue));
     }, metrics.onKafkaStats);
 
     // Empty topics will never trigger a stream event. So we're already ready

--- a/lib/index.js
+++ b/lib/index.js
@@ -113,6 +113,13 @@ function createMetricsApi({ metrics, log }) {
   }
 }
 
+function getGroupId() {
+  const suffix = process.env.KAFKA_CACHE_GROUP_SUFFIX;
+  if (!suffix) throw new Error('Missing env KAFKA_CACHE_GROUP_SUFFIX');
+
+  return 'node-kafka-cache_' + suffix;
+}
+
 function createKafkaStream({ topic, kafkaHost, consumeFromTimestamp, log }) {
 
   const consumerOptions = {
@@ -133,8 +140,10 @@ function createKafkaStream({ topic, kafkaHost, consumeFromTimestamp, log }) {
 
       log.info({ topic, kafkaHost, consumeFromOffset, consumeFromTimestamp }, 'Setting up kafka stream starting from offset');
 
+      const groupId = getGroupId();
+
       resolve({
-        stream: kafka.stream.bind(null, topic, 'node-kafka-cache', consumerOptions, consumeFromOffset),
+        stream: kafka.stream.bind(null, topic, groupId, consumerOptions, consumeFromOffset),
         currentTopicOffset: readyOffset
       });
     });

--- a/lib/large-gzip-topics.itest.js
+++ b/lib/large-gzip-topics.itest.js
@@ -24,6 +24,52 @@ function getTopicName(suffix) {
   return Date.now() + '_' + suffix;
 }
 
+describe('consumption from several different kafka caches', function () {
+
+  it('keeps the caches in sync between each other', async function () {
+    this.timeout(10000);
+    const topic = getTopicName('foobar.json.');
+
+    const createCache = () => KafkaCache.create({
+      kafkaHost: 'kafka:9092',
+      topic,
+      readOnly: false
+    });
+
+    const cache1 = createCache();
+    await cache1.onReady();
+
+
+    const kafkaWrite = KafkaCache.createKafkaWrite({
+      topic,
+      kafkaHost: 'kafka:9092',
+    });
+
+    const offset = await kafkaWrite(aguid('key1'), { foo: 'bar' });
+    await cache1.waitForOffset(offset);
+
+    const cache2 = createCache();
+    await cache2.onReady();
+
+    const value1 = await cache1.get(aguid('key1'), 'cache1 contains the correct key');
+    const value2 = await cache2.get(aguid('key1'), 'cache1 contains the correct key');
+
+    expect(value1).to.deep.equal({ foo: 'bar' });
+    expect(value2).to.deep.equal({ foo: 'bar' });
+
+    const offsetReady = cache2.put(aguid('key2'), { foo: 'bar' });
+
+    const offset2 = await offsetReady;
+    await cache1.waitForOffset(offset2);
+    const value4 = await cache1.get(aguid('key2'));
+    expect(value4).to.deep.equal({ foo: 'bar' });
+
+    const value3 = await cache2.get(aguid('key2'));
+    expect(value3).to.deep.equal({ foo: 'bar' });
+
+  });
+});
+
 describe('how kafka-cache handles large gzip topics that we invented ourselves', function () {
 
   it('it only ever reads the last message when asked for', async function () {

--- a/test/KafkaCache.spec.js
+++ b/test/KafkaCache.spec.js
@@ -14,6 +14,68 @@ function createMockMetricsApi() {
 
 describe('KafkaCache unit-tests', function () {
 
+  it('exposes an additional .waitForOffset functionality that becomes important when kafka is backing a cache', async function () {
+    const logger = {
+      debug: simple.spy(),
+      error: simple.spy((...args) => console.error(...args)),
+      info: simple.spy(),
+      warn: simple.spy()
+    };
+
+    const mocks = {
+      stream: simple.mock()
+    };
+
+    const metricsApi = createMockMetricsApi();
+
+    const cache = new KafkaCache({
+      streamReady: Promise.resolve({ stream: mocks.stream, currentTopicOffset: -1 }),
+      log: logger,
+      levelupOptions: {
+        keyEncoding: 'utf-8',
+        valueEncoding: 'json'
+      },
+      resolver: x => x,
+      metrics: metricsApi
+    });
+
+    await cache.onReady();
+
+    const produceFlakyMessage = (message) => {
+      setTimeout(() => {
+        mocks.stream.lastCall.arg(message);
+      }, Math.random() * 50);
+    }
+
+    // Support listeners registered before the offset is present
+    const offsetReady = cache.waitForOffset(0);
+    produceFlakyMessage({
+      key: 'key1',
+      value: Buffer.from(JSON.stringify({ foo: 'bar' })),
+      offset: 0
+    });
+    await offsetReady;
+    const value = await cache.get('key1');
+    expect(value).to.deep.equal({ foo: 'bar' });
+
+    // Support listeners registered after the offset was already received
+    produceFlakyMessage({
+      key: 'key2',
+      value: Buffer.from(JSON.stringify({ foo: 'bar' })),
+      offset: 2
+    });
+    produceFlakyMessage({
+      key: 'key2',
+      value: Buffer.from(JSON.stringify({ foo: 'bar' })),
+      offset: 3
+    });
+    await offsetReady;
+    await cache.waitForOffset(3);
+    await cache.waitForOffset(2);
+    const value2 = await cache.get('key2');
+    expect(value2).to.deep.equal({ foo: 'bar' });
+  });
+
   it('ignores payloads with missing keys but logs them and reports them as metrics', async function () {
 
     const logger = {


### PR DESCRIPTION
Pushed as `yolean/node-kafka-cache@sha256:acd157dccf61b014b98b5b8345d25b4f6baeab75821b267d6cb17dc0acde6ae8`

Contains #25, to be considered quite unstable. But better than what we have in production in applications using kafka-cache.