### PR TITLE
Explicit per-producer pre-compression message size cap

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,7 @@ const defaults = {
   valueEncoding: 'json',
   keyEncoding: 'utf-8',
   writeCompression: 'snappy', // snappy,gzip etc?
+  writeMaxBytesUncompressed: 1048576, // http://kafka.apache.org/documentation/#producerconfigs_max.request.size
   compressValues: false,
   log: require('./log'),
   readOnly: true, // defaulting to false would mean we might open a lot of unnecessary producers
@@ -150,7 +151,7 @@ function createKafkaStream({ topic, kafkaHost, consumeFromTimestamp, log }) {
   });
 }
 
-function createKafkaWrite(streamReady, { log, topic, kafkaHost, writeCompression, readOnly }, customValueEncoding) {
+function createKafkaWrite(streamReady, { log, topic, kafkaHost, writeCompression, writeMaxBytesUncompressed, readOnly }, customValueEncoding) {
   log.debug({ readOnly, hasCustomValueEncoding: !!customValueEncoding }, 'Setting up kafka write producer');
 
   if (readOnly) return () => { throw new Error('KafkaCache.put is disabled for readOnly caches, please create the cache with readOnly=false!'); }
@@ -162,6 +163,8 @@ function createKafkaWrite(streamReady, { log, topic, kafkaHost, writeCompression
     return kafka.createProducer({
      'metadata.broker.list': kafkaHost,
      'compression.codec': writeCompression,
+     // https://github.com/edenhill/librdkafka/issues/3246#issuecomment-774001962
+     'message.max.bytes': writeMaxBytesUncompressed,
      // TODO I don't know how we should set this for a more generic case
      // 'queue.buffering.max.ms': PRODUCER_MAX_WAIT
    });

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,8 @@ const { getCustomEncoding } = require('./custom-encodings');
 const moment = require('moment');
 const { promisify } = require('util');
 
+const envMaxB = 'KAFKA_CACHE_DEFAULT_WRITE_MAX_BYTES_UNCOMPRESSED';
+
 const defaults = {
   kafkaHost: 'http://localhost:9092', // We never talked about this one but I guess it's required nonetheless
   // topic: 'build-contract.basics.001',
@@ -11,7 +13,7 @@ const defaults = {
   valueEncoding: 'json',
   keyEncoding: 'utf-8',
   writeCompression: 'snappy', // snappy,gzip etc?
-  writeMaxBytesUncompressed: 1048576, // http://kafka.apache.org/documentation/#producerconfigs_max.request.size
+  writeMaxBytesUncompressed: process.env[envMaxB] && parseInt(process.env[envMaxB]) || 1048576, // http://kafka.apache.org/documentation/#producerconfigs_max.request.size
   compressValues: false,
   log: require('./log'),
   readOnly: true, // defaulting to false would mean we might open a lot of unnecessary producers


### PR DESCRIPTION
while the broker/topic max.message.bytes is after compression. See references in source.